### PR TITLE
Loki navigation

### DIFF
--- a/update-magni-image.sh
+++ b/update-magni-image.sh
@@ -26,21 +26,6 @@ function get_source {
 echo "Upgrading installed packages"
 sudo apt-get update && sudo apt-get upgrade -y
 
-# Install some packages if not already installed
-echo "Installing extra packages"
-sudo apt-get install ros-kinetic-teleop-twist-keyboard
-
-# If current packages are not available via debs, then build from source
-if [[ ! `apt-cache policy ros-kinetic-move-basic` =~ "Installed: 0.2.2" ]]; then
-   get_source 'move_basic'
-fi
-if [[ ! `apt-cache policy ros-kinetic-magni-robot` =~ "Installed: 0.2.1" ]]; then
-   get_source 'magni_robot'
-fi
-
 get_source 'ubiquity_launches'
-
-echo "Bullding"
-cd ~/catkin_ws && catkin_make
 
 echo "Done"

--- a/update-magni-image.sh
+++ b/update-magni-image.sh
@@ -34,6 +34,9 @@ sudo apt-get install ros-kinetic-teleop-twist-keyboard
 if [[ ! `apt-cache policy ros-kinetic-move-basic` =~ "Installed: 0.2.2" ]]; then
    get_source 'move_basic'
 fi
+if [[ ! `apt-cache policy ros-kinetic-magni-robot` =~ "Installed: 0.2.1" ]]; then
+   get_source 'magni_robot'
+fi
 
 get_source 'ubiquity_launches'
 

--- a/update-magni-image.sh
+++ b/update-magni-image.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+:<<"END_COMMENT"
+
+ This script updates a system updated from the ubiquity image to incoporate changes
+ made since the last release
+
+ Invoke with this command:
+
+ wget -O - https://raw.githubusercontent.com/UbiquityRobotics/ubiquity_main/kinetic/update-magni-image.sh | bash
+
+END_COMMENT
+
+function get_source {
+  pkg=$1
+  echo "Installing ${pkg} from source"
+  if [ -d ~/catkin_ws/src/${pkg} ]; then
+     echo "Source directory exists"
+     cd ~/catkin_ws/src/${pkg} && git pull
+  else
+    cd ~/catkin_ws/src && git clone https://github.com/UbiquityRobotics/${pkg}.git
+  fi
+}
+
+# We are always going to want to do this
+echo "Upgrading installed packages"
+sudo apt-get update && sudo apt-get upgrade -y
+
+# Install some packages if not already installed
+echo "Installing extra packages"
+sudo apt-get install ros-kinetic-teleop-twist-keyboard
+
+# If current packages are not available via debs, then build from source
+if [[ ! `apt-cache policy ros-kinetic-move-basic` =~ "Installed: 0.2.2" ]]; then
+   get_source 'move_basic'
+fi
+
+get_source 'ubiquity_launches'
+
+echo "Bullding"
+cd ~/catkin_ws && catkin_make
+
+echo "Done"

--- a/update-magni-image.sh
+++ b/update-magni-image.sh
@@ -7,7 +7,7 @@
 
  Invoke with this command:
 
- wget -O - https://raw.githubusercontent.com/UbiquityRobotics/ubiquity_main/kinetic/update-magni-image.sh | bash
+ wget -O - https://ubiquityrobotics.com/patch-script | bash
 
 END_COMMENT
 


### PR DESCRIPTION
I loaded teleop launch (minus the logitech driver, added magni_nav move_basic, aruco and observed the following:

Fiducials were being detected in proper orientation to the robot.  (I ran fiducial slam rviz) and the robot appeared to be in the correct orientation relative to three overhead fiducials.

I set a 2-d nav goal about 10cm from the robot's position,  the robot took off for some other location perhaps in another time zone.

I next tried robot commander:

Arrow keys work.

Voice forward, rotate work  
Voice halt, stop do not work
Forward 10 cm  - no movement.
Right 90 degrees - robot went forward

Unknown what the issues are at this point, in November  robot commander + move_basic had rotate 90 degrees, forward 10cm working, but no ability to set way points since camera was not being used.  Can someone test and verify what I am seeing.

I have further tested the fiducial_follow.launch in loki_demos. I have added move_basic to the launch sequence to be consistent with Magni  - it is unclear that loki needs move_basic??

Result. on seeing the marker 49, the robot reverses rapidly for about a meter, and then seems to search for but move away from not toward the marker.  Removal of the marker form the field of view, the robot goes to recovery mode.   

I have not tested with